### PR TITLE
Fixed runtime conversion of 2d Arrays

### DIFF
--- a/fontus/src/main/java/com/sap/fontus/utils/ConversionUtils.java
+++ b/fontus/src/main/java/com/sap/fontus/utils/ConversionUtils.java
@@ -197,6 +197,9 @@ public final class ConversionUtils {
 
     // TODO: Can't we get the list of the classes based on the Maps above? This is super ugly and error prone (it seems to be missing entries, but that might be what we want?
     private static boolean isHandleable(Class<?> cls) {
+        while(cls.isArray()) {
+            cls = cls.getComponentType();
+        }
         return cls == String.class || cls == StringBuilder.class || cls == StringBuffer.class || cls == Formatter.class || cls == Pattern.class || cls == Matcher.class || cls == Properties.class || Type.class.isAssignableFrom(cls) || cls == Method.class || cls == Field.class;
     }
 

--- a/fontus/src/test/java/com/sap/fontus/utils/ConversionUtilsTest.java
+++ b/fontus/src/test/java/com/sap/fontus/utils/ConversionUtilsTest.java
@@ -2,6 +2,7 @@ package com.sap.fontus.utils;
 
 import com.sap.fontus.config.Configuration;
 import com.sap.fontus.config.TaintMethod;
+import com.sap.fontus.taintaware.unified.IASString;
 import com.sap.fontus.taintaware.unified.reflect.IASField;
 import com.sap.fontus.taintaware.unified.reflect.IASMethod;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.BeforeAll;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.text.DateFormatSymbols;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,5 +47,15 @@ class ConversionUtilsTest {
         assertTrue(converted instanceof IASField[]);
         assertEquals("f1", ((IASField[]) converted)[0].getName().getString());
         assertEquals("f2", ((IASField[]) converted)[1].getName().getString());
+    }
+
+    @Test
+    void test2dArrays() {
+        Locale lc = Locale.US;
+        DateFormatSymbols dfs = DateFormatSymbols.getInstance(lc);
+        String[][] zs = dfs.getZoneStrings();
+        Object o = ConversionUtils.convertToInstrumented(zs);
+        IASString[][] czs = (IASString[][]) o;
+        assertEquals(czs.length, zs.length);
     }
 }


### PR DESCRIPTION
The code in the test case is lifted from the following call: `org.apache.logging.log4j.core.util.datetime.FastDateParser$TimeZoneStrategy.<init>`

This failed before because Fontus did not detect String[][] as something it could convert. This adds the required logic to the ConversionUtils.

This adds an additional branch in the hot path, so it might have a performance impact. The comment above the isHandleable() method rings very true indeed.