### PR TITLE
Added basic validation to Fontus' configuration.

### DIFF
--- a/fontus/src/main/java/com/sap/fontus/agent/TaintAgent.java
+++ b/fontus/src/main/java/com/sap/fontus/agent/TaintAgent.java
@@ -14,6 +14,8 @@ public class TaintAgent {
         InstrumentationConfiguration.init(null, null);
         Configuration.parseAgent(args);
 
+        Configuration.getConfiguration().validate();
+
         if (Configuration.getConfiguration().isShowWelcomeMessage()) {
             System.out.println("Starting application with Fontus Tainting!");
             System.out.println("  * Loaded " + Configuration.getConfiguration().summary());

--- a/fontus/src/main/java/com/sap/fontus/config/Configuration.java
+++ b/fontus/src/main/java/com/sap/fontus/config/Configuration.java
@@ -14,6 +14,8 @@ import com.sap.fontus.utils.Logger;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.File;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -139,7 +141,6 @@ public class Configuration {
         this.resourcesToInstrument = new ArrayList<>();
         this.passThroughTaints = new ArrayList<>();
         this.propagateTaintInFunctions = new ArrayList<>();
-
     }
 
     public Configuration(boolean verbose,
@@ -651,5 +652,18 @@ public class Configuration {
 
     public void setSpeculativeInstrumentation(boolean speculativeInstrumentation) {
         this.speculativeInstrumentation = speculativeInstrumentation;
+    }
+
+    public boolean validate() {
+        for(FunctionCall fc : this.converters) {
+            try {
+                Method m = FunctionCall.toMethod(fc);
+            } catch(ExceptionInInitializerError ex) {
+                System.out.printf("Converter '%s' is invalid due to: %s%n", fc.getName(), ex.getCause().getMessage());
+            } catch (ClassNotFoundException | NoSuchMethodException ex) {
+                System.out.printf("Converter '%s' is invalid due to: %s%n", fc.getName(), ex.getMessage());
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
First step towards #14.

It is fairly easy to leave old clutter in your configuration, which will, in some cases, fail more or less silently.

For example, I just copied a config from one of the tested programs for the CCS paper, and it contained the following converter:

```xml
<converter>
    <opcode>184</opcode>
    <owner>de/tubs/cs/ias/asm_test/taintaware/shared/IASStringUtils</owner>
    <name>convertTStringList</name>
    <descriptor>(Ljava/util/List;)Ljava/util/List;</descriptor>
    <interface>false</interface>
</converter>
```

This predates the name change, which is like 2y+ old. In case the converter was actually applied, this would try to call a method that does not exist anymore.

This patch aims to fix this by trying to assess whether the converters are actually in the classpath. It only prints out warnings, as failing would be a) a breaking change b) prevent building a generic configuration that works across programs.

The latter is due to the fact that we ship some converters which rely on the presence of third-party libraries, such as
[DGMMethodConverter](https://github.com/SAP/project-fontus/blob/main/fontus/src/main/java/com/sap/fontus/manual/groovy/converters/DGMMethodConverter.java). It is also included in most Fontus configs I have on my system, so it's probably fairly widespread. I'd like to avoid breaking all of them, so this simply warns if you define converters that can not be applied without error.

Example output:
```txt
java.lang.ClassNotFoundException: org.codehaus.groovy.reflection.GeneratedMetaMethod$DgmMethodRecord
	at com.sap.fontus.manual.groovy.converters.DGMMethodConverter.<clinit>(DGMMethodConverter.java:20)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:315)
	at com.sap.fontus.asm.FunctionCall.toMethod(FunctionCall.java:110)
	at com.sap.fontus.config.Configuration.validate(Configuration.java:660)
	at com.sap.fontus.agent.TaintAgent.premain(TaintAgent.java:16)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
Converter 'convertTypes' is invalid due to: java.lang.ClassNotFoundException: org.codehaus.groovy.reflection.GeneratedMetaMethod$DgmMethodRecord
Converter 'convertStringList' is invalid due to: de.tubs.cs.ias.asm_test.taintaware.shared.IASStringUtils
Converter 'convertTStringList' is invalid due to: de.tubs.cs.ias.asm_test.taintaware.shared.IASStringUtils
Converter 'convertTStringToTStringHashTable' is invalid due to: de.tubs.cs.ias.asm_test.taintaware.shared.IASStringUtils
Converter 'convertStringMapToTStringMap' is invalid due to: de.tubs.cs.ias.asm_test.taintaware.shared.IASStringUtils
Converter 'convertStringHashtableToTStringHashtable' is invalid due to: de.tubs.cs.ias.asm_test.taintaware.shared.IASStringUtils
```

The stack trace originates from the [DGMMethodConverter](https://github.com/SAP/project-fontus/blob/main/fontus/src/main/java/com/sap/fontus/manual/groovy/converters/DGMMethodConverter.java#L26), I'll clean that up separately.