### PR TITLE
Added support for default Properties.

### DIFF
--- a/fontus/src/test/java/com/sap/fontus/taintaware/unified/IASPropertiesTest.java
+++ b/fontus/src/test/java/com/sap/fontus/taintaware/unified/IASPropertiesTest.java
@@ -1,0 +1,31 @@
+package com.sap.fontus.taintaware.unified;
+
+import com.sap.fontus.config.Configuration;
+import com.sap.fontus.config.TaintMethod;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class IASPropertiesTest {
+    @BeforeAll
+    static void setup() {
+        Configuration.setTestConfig(TaintMethod.RANGE);
+    }
+
+
+    @Test
+    public void testProperties() {
+        IASProperties defaults = new IASProperties();
+        defaults.setProperty(IASString.fromString("sup"), IASString.fromString("son"));
+        IASString k2 = IASString.fromString("what's");
+        IASProperties user = new IASProperties(defaults);
+        user.setProperty(k2, IASString.fromString("up"));
+
+        IASString g2 = user.getProperty(k2);
+        IASString g1 = user.getProperty(IASString.fromString("sup"));
+
+        Assert.assertEquals(IASString.fromString("up"), g2);
+        Assert.assertEquals(IASString.fromString("son"), g1);
+    }
+
+}


### PR DESCRIPTION
The Properties class is a thorn in our side since basically forever. We have something in place that mostly works, but sometimes goes up in a ball of flames. I found a case of the latter today.

Unlike the JDK Properties, ours did not expose the defaults field which allows to delegate lookup to an upper Property map. This fixes the presence and usage of the defaults field.

It's still not fully supported, as we e.g., do not write out the default keys when `stringPropertyNames()` is called.