### PR TITLE
Conditionally add interface proxies for taint persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ java --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/j
 ### Parameters
 It is also possible to pass multiple parameters to the agent
 - **verbose**: If this option is set, all instrumented classes are saved to ``./tmp/agent``
+- **taint_persistence**: If set, this flag enables applying the proxies for persisting taints.
 - **logging_enabled**: If this option is set, a log file of the instrumentation process will be created in the working dir named ``asm-{datetime}.log`` 
 - **taintmethod**: Specifying the used taint method. For all options see [Available Tainting Methods](#Available Tainting Methods). The default is *boolean*
 - **use_caching**: Possible values: *true* or *false*. Default is true. Enables/Disables caching of taint evaluation results for lazy tainting methods

--- a/fontus/src/main/java/com/sap/fontus/agent/AgentConfig.java
+++ b/fontus/src/main/java/com/sap/fontus/agent/AgentConfig.java
@@ -88,7 +88,7 @@ public class AgentConfig {
             if ("verbose".equals(part)) {
                 verbose = true;
             }
-            if ("persistence".equals(part)) {
+            if ("taint_persistence".equals(part)) {
                 taintPersistence = true;
             }
             if ("persistent_cache".equals(part)) {

--- a/fontus/src/main/java/com/sap/fontus/instrumentation/ClassTaintingVisitor.java
+++ b/fontus/src/main/java/com/sap/fontus/instrumentation/ClassTaintingVisitor.java
@@ -75,7 +75,7 @@ class ClassTaintingVisitor extends ClassVisitor {
         this.fillBlacklist();
         this.signatureInstrumenter = new SignatureInstrumenter(this.api, this.instrumentationHelper);
         this.combinedExcludedLookup = excludedLookup;
-        this.methodProxies = new MethodProxies(this.combinedExcludedLookup);
+        this.methodProxies = new MethodProxies(this.combinedExcludedLookup, this.config);
     }
 
     private void fillBlacklist() {

--- a/fontus/src/main/java/com/sap/fontus/instrumentation/MethodProxies.java
+++ b/fontus/src/main/java/com/sap/fontus/instrumentation/MethodProxies.java
@@ -1,6 +1,7 @@
 package com.sap.fontus.instrumentation;
 
 import com.sap.fontus.asm.FunctionCall;
+import com.sap.fontus.config.Configuration;
 import com.sap.fontus.taintaware.unified.*;
 import com.sap.fontus.taintaware.unified.reflect.*;
 import com.sap.fontus.utils.LogUtils;
@@ -155,6 +156,10 @@ public class MethodProxies {
                 new FunctionCall(Opcodes.INVOKESTATIC, Type.getInternalName(IASToArrayProxy.class), "toArray", String.format("(L%s;[Ljava/lang/Object;)[Ljava/lang/Object;", Utils.dotToSlash(Collection.class.getName())), false));
         methodInterfaceProxies.put(new FunctionCall(Opcodes.INVOKEVIRTUAL, "java/util/Collection", "toArray", "()[Ljava/lang/Object;", true),
                 new FunctionCall(Opcodes.INVOKESTATIC, Type.getInternalName(IASToArrayProxy.class), "toArray", String.format("(L%s;)[Ljava/lang/Object;", Utils.dotToSlash(Collection.class.getName())), false));
+
+    }
+
+    private static void fillTaintPersistenceProxies() {
         methodInterfaceProxies.put(new FunctionCall(Opcodes.INVOKEVIRTUAL, "java/sql/PreparedStatement", "setString", "(ILjava/lang/String;)V", true),
                 new FunctionCall(Opcodes.INVOKESTATIC, Type.getInternalName(IASPreparedStatementUtils.class), "setString", String.format("(L%s;ILcom/sap/fontus/taintaware/unified/IASString;)V", Utils.dotToSlash(java.sql.PreparedStatement.class.getName())), false));
         methodInterfaceProxies.put(new FunctionCall(Opcodes.INVOKEVIRTUAL, "java/sql/PreparedStatement", "setNString", "(ILjava/lang/String;)V", true),
@@ -200,8 +205,11 @@ public class MethodProxies {
 
     CombinedExcludedLookup combinedExcludedLookup;
 
-    MethodProxies(CombinedExcludedLookup combinedExcludedLookup) {
+    MethodProxies(CombinedExcludedLookup combinedExcludedLookup, Configuration configuration) {
         this.combinedExcludedLookup = combinedExcludedLookup;
+        if(configuration.hasTaintPersistence()) {
+            fillTaintPersistenceProxies();
+        }
     }
 
     /**

--- a/fontus/src/main/java/com/sap/fontus/instrumentation/MethodTaintingVisitor.java
+++ b/fontus/src/main/java/com/sap/fontus/instrumentation/MethodTaintingVisitor.java
@@ -69,7 +69,7 @@ public class MethodTaintingVisitor extends BasicMethodVisitor {
         this.isOwnerInterface = isOwnerInterface;
         this.config = config;
         this.combinedExcludedLookup = combinedExcludedLookup;
-        this.methodProxies = new MethodProxies(this.combinedExcludedLookup);
+        this.methodProxies = new MethodProxies(this.combinedExcludedLookup, this.config);
         this.bootstrapMethods = bootstrapMethods;
         logger.info("Instrumenting method: {}{}", name, methodDescriptor);
         this.used = Type.getArgumentsAndReturnSizes(methodDescriptor) >> 2;


### PR DESCRIPTION
If we always load the proxies and do not use the taint persistence driver, which might be the sensible path due to
performance/compatibility restrictions the application will break.

As the focus is not purely on GDPR tainting anymore, the addition of the problematic proxies is hidden behind a flag has has to be passed to the agent.

It would be nicer to dynamically detect this, but this a) might be slow and b) is fairly complex.