### PR TITLE
Fixed and clarified usage of ReflectedObject.

### DIFF
--- a/fontus/src/main/java/com/sap/fontus/gdpr/servlet/ReflectedObject.java
+++ b/fontus/src/main/java/com/sap/fontus/gdpr/servlet/ReflectedObject.java
@@ -9,12 +9,15 @@ public abstract class ReflectedObject {
 
     protected final Object o;
 
+    /**
+     * Calls a static method via reflection.
+     */
     public static Object callMethodWithReflection(Class<?> c, Method m, Object... args) {
         Object result = null;
         try {
             Method originalMethod = c.getMethod(m.getName(), m.getParameterTypes());
             // TODO: check whether this is a bug with the missing instance parameter.
-            result = originalMethod.invoke(args);
+            result = originalMethod.invoke(null, args);
         } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
             System.err.println("FONTUS Exception with reflected call: " + c.getName() + "." + m.getName() + ": " + e.getMessage());
         }

--- a/fontus/src/test/java/com/sap/fontus/gdpr/servlet/ReflectedObjectTests.java
+++ b/fontus/src/test/java/com/sap/fontus/gdpr/servlet/ReflectedObjectTests.java
@@ -1,0 +1,33 @@
+package com.sap.fontus.gdpr.servlet;
+
+import com.sap.fontus.config.Configuration;
+import com.sap.fontus.config.TaintMethod;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReflectedObjectTests {
+    @BeforeAll
+    static void init() {
+        Configuration.setTestConfig(TaintMethod.RANGE);
+    }
+
+    @Test
+    public void testCallWithReflection() {
+        Widget w = new Widget("foobar");
+        ReflectedWidget rw = new ReflectedWidget(w);
+        assertEquals("foobar", rw.getName());
+    }
+
+    @Test
+    public void testStaticCallWithReflection() {
+        assertEquals("Widget", ReflectedWidget.getClassName());
+        ReflectedWidget.setClassName("foobar");
+        assertEquals("foobar", ReflectedWidget.getClassName());
+
+    }
+
+}

--- a/fontus/src/test/java/com/sap/fontus/gdpr/servlet/ReflectedWidget.java
+++ b/fontus/src/test/java/com/sap/fontus/gdpr/servlet/ReflectedWidget.java
@@ -1,0 +1,26 @@
+package com.sap.fontus.gdpr.servlet;
+
+import java.lang.reflect.Method;
+
+class ReflectedWidget extends ReflectedObject {
+    ReflectedWidget(Object o) {
+        super(o);
+    }
+
+    String getName() {
+        Method em = new Object() {
+        }.getClass().getEnclosingMethod();
+        System.out.println(em);
+        return (String) callMethodWithReflection(em);
+    }
+
+    public static String getClassName() {
+        return (String) callMethodWithReflection(Widget.class, new Object() {
+        }.getClass().getEnclosingMethod());
+    }
+
+    public static void setClassName(String s) {
+        callMethodWithReflection(Widget.class, new Object() {
+        }.getClass().getEnclosingMethod(), s);
+    }
+}

--- a/fontus/src/test/java/com/sap/fontus/gdpr/servlet/Widget.java
+++ b/fontus/src/test/java/com/sap/fontus/gdpr/servlet/Widget.java
@@ -1,0 +1,20 @@
+package com.sap.fontus.gdpr.servlet;
+
+class Widget {
+    private String name;
+    private static String className = "Widget";
+    Widget(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+    public static void setClassName(String s) {
+        className = s;
+    }
+
+    public static String getClassName() {
+        return className;
+    }
+}


### PR DESCRIPTION
Before, calling static methods would not work properly when going the ReflectedObject route. This was due to a missing null parameter that signals a static invocation to `Method.invoke()`. This is now fixed and clarified via a comment.

It also adds two unit tests to use the two ways to call a function via reflection. Silences some Intellij/SpotBugs warnings.