### PR TITLE
build: Moved to/added SapMachine

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -12,12 +12,13 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: "Checkout repository"
+      uses: actions/checkout@v4
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'temurin'
+        java-version: '17'
+        distribution: 'sapmachine'
 
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
     # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,17 +10,18 @@ jobs:
   build:
     strategy:
       matrix:
-        distribution: ['temurin', 'zulu', 'microsoft', 'corretto', 'semeru', 'dragonwell']
+        distribution: ['temurin', 'zulu', 'microsoft', 'corretto', 'semeru', 'dragonwell', 'sapmachine']
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: "Checkout repository"
+      uses: actions/checkout@v4
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: ${{ matrix.distribution }}
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
@@ -31,17 +32,18 @@ jobs:
   system-tests:
     strategy:
       matrix:
-        distribution: ['temurin', 'zulu', 'microsoft', 'corretto', 'semeru', 'dragonwell']
+        distribution: ['temurin', 'zulu', 'microsoft', 'corretto', 'semeru', 'dragonwell', 'sapmachine']
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: "Checkout repository"
+      uses: actions/checkout@v4
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: ${{ matrix.distribution }}
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
Hi Colleagues,

[SapMachine](https://sapmachine.io/) is now available with
actions/setup-java@v4
Created a PR to migrate from Temurin 11 to SapMachine 17 and
added SapMachine to your list and updated to Java 17.
Please note that since the last Oct2024 release that Java 11 has no real progress anymore (cf the Backlog Items in OpenJDK). We Hardly recommend to update to minimum Java 17 LTS or to recent Java 21 LTS.
Regards Christian@SapMachine Team